### PR TITLE
minor navbar changes

### DIFF
--- a/styles/nav.css
+++ b/styles/nav.css
@@ -5,19 +5,20 @@
 }
 
 .header img {
-  width: 170px;
+  width: 120px;
   margin-left: 1em;
 }
 
 .nav {
   display: flex;
-  margin-left: 4em;
+  margin-left: 2em;
+  flex-wrap: wrap;
 }
 
 .nav__btn {
   text-decoration: none;
   color: #000000;
-  font-size: 30px;
+  font-size: 20px;
   margin: 0 1em;
 }
 
@@ -27,6 +28,10 @@
 
 .nav__btn--active {
   border-bottom: 2px solid black;
+}
+
+.nav__btn--active:hover {
+  border-bottom: 2px solid #555555;
 }
 
 


### PR DESCRIPTION
## changes:
1) added `flex-wrap: wrap` to navbar links for responsiveness
2) added hover color change present on other links to the `nav__btn--active` class
3) resized Count image (and thus navbar height) from 170px down to 120px
4) changed navbar link text to 20px from 30px
5) changed margin-left on the navbar (margin away from the Count logo) from 4em to 2em, reducing the distance between the logo and the navbar links

## testing:
1) fetch and serve branch _ar-navbar-tweaks_ and open _pages/canada.html_ in browser
2) resize browser window to ensure navbar links wrap when window shrinks
3) hover over active link in navbar ("Canada") to make sure the underline changes to a light gray color like the text does